### PR TITLE
Add install remotes module

### DIFF
--- a/lib/hanzo.rb
+++ b/lib/hanzo.rb
@@ -1,5 +1,6 @@
 require 'optparse'
-require "highline/import"
+require 'yaml'
+require 'highline/import'
 
 require 'hanzo/cli'
 require 'hanzo/version'

--- a/lib/hanzo/modules/install.rb
+++ b/lib/hanzo/modules/install.rb
@@ -1,0 +1,38 @@
+require 'hanzo/modules/install/remotes'
+
+module Hanzo
+  class Install
+
+    include Hanzo::Install::Remotes
+
+    attr_accessor :options
+
+    def initialize(args)
+      @args = args
+      @type = (@args[1] =~ /-/) ? nil : @args[1]
+
+      init_cli
+    end
+
+    protected
+
+      def init_cli
+        opts = OptionParser.new
+
+        if @type.nil?
+          opts.banner = <<-BANNER
+Usage: hanzo install TYPE
+
+Available install type:
+  remotes — Add git remotes to current repository
+BANNER
+        else
+          send("install_#{@type}")
+          opts = nil
+        end
+
+        @options = opts
+      end
+
+  end
+end

--- a/lib/hanzo/modules/install/remotes.rb
+++ b/lib/hanzo/modules/install/remotes.rb
@@ -1,0 +1,24 @@
+module Hanzo
+  class Install
+    module Remotes
+
+      def install_remotes
+        puts '-----> Creating git remotes'
+
+        if File.exists?('.heroku-remotes')
+          envs = YAML.load_file('.heroku-remotes')
+
+          envs.each_pair do |env, app|
+            puts "       Adding #{env}"
+            `git remote rm #{env} 2>&1 > /dev/null`
+            `git remote add #{env} git@heroku.com:#{app}.git`
+          end
+        else
+          puts '       Can\'t locate .heroku-remotes'
+          puts '       For more information, please read https://github.com/mirego/hanzo'
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
If everything is ok

```
> be hanzo install remotes 
-----> Creating git remotes
       Adding ci           
       Adding qa           
       Adding staging
       Adding production
```

If `.heroku-remotes` is missing

```
> be hanzo install remotes                                
-----> Creating git remotes                               
       Can't locate .heroku-remotes                       
       For more information, please read https://github.com/mirego/hanzo
```

Afterward, all environments are available for deployment.
