### PR TITLE
Run migration post deploy

### DIFF
--- a/hanzo.gemspec
+++ b/hanzo.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
 
   spec.add_dependency 'highline'
+  spec.add_dependency 'heroku'
 end

--- a/lib/hanzo/modules/deploy.rb
+++ b/lib/hanzo/modules/deploy.rb
@@ -21,6 +21,9 @@ module Hanzo
       branch = ask("-----> Branch to deploy in #{@env}: ") { |q| q.default = "HEAD" }
 
       `git push -f #{@env} #{branch}:master`
+
+      migration = agree("-----> Run migrations? ")
+      `bundle exec heroku run rake db:migrate --remote #{@env}` if migration
     end
 
   end


### PR DESCRIPTION
Will run `heroku run rake db:migrate` after a successful deployment. Otherwise, we might forget it...
