### PR TITLE
Remove heroku gem dependency

### DIFF
--- a/hanzo.gemspec
+++ b/hanzo.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
 
   spec.add_dependency 'highline'
-  spec.add_dependency 'heroku'
 end

--- a/lib/hanzo/heroku.rb
+++ b/lib/hanzo/heroku.rb
@@ -3,7 +3,7 @@ module Hanzo
     class << self
 
       def available_labs
-        `bundle exec heroku labs`.each_line.to_a.inject([]) do |memo, line|
+        `heroku labs`.each_line.to_a.inject([]) do |memo, line|
           if line = /^\[\s\]\s+(?<name>\w+)\s+(?<description>.+)$/.match(line)
             memo << [line[:name], line[:description]]
           else

--- a/lib/hanzo/modules/deploy.rb
+++ b/lib/hanzo/modules/deploy.rb
@@ -27,7 +27,7 @@ module Hanzo
     def run_migrations
       if Dir.exists?('db/migrate')
         migration = agree("-----> Run migrations? ")
-        `bundle exec heroku run rake db:migrate --remote #{@env}` if migration
+        `heroku run rake db:migrate --remote #{@env}` if migration
       end
     end
   end

--- a/lib/hanzo/modules/installers/labs.rb
+++ b/lib/hanzo/modules/installers/labs.rb
@@ -14,7 +14,7 @@ module Hanzo
       end
 
       def self.enable(env, lab)
-        `bundle exec heroku labs:enable #{lab} --remote #{env}`
+        `heroku labs:enable #{lab} --remote #{env}`
         puts "       - Enabled for #{env}"
       end
     end


### PR DESCRIPTION
Since the `heroku` gem [is now deprecated](https://github.com/heroku/heroku/blob/726da666f4aca330c219bb12876cf8b32d79cc05/heroku.gemspec#L15-L19), we should no longer require it.

Users are expected to have the [Heroku Toolbelt](https://toolbelt.heroku.com/) installed.
