### PR TITLE
Deploy to single remote if no one is passed

### DIFF
--- a/lib/hanzo/modules/deploy.rb
+++ b/lib/hanzo/modules/deploy.rb
@@ -5,6 +5,10 @@ module Hanzo
 
     def initialize_variables
       @env = extract_argument(1)
+
+      if @env.nil? and Hanzo::Installers::Remotes.environments.keys.length == 1
+        @env = Hanzo::Installers::Remotes.environments.keys.first
+      end
     end
 
     def initialize_cli


### PR DESCRIPTION
If there’s only one line in `.heroku-remotes`, running `hanzo deploy` without any remote will deploy to it.
