### PR TITLE
Fix “config compare” by fixing Hanzo.run

### DIFF
--- a/lib/hanzo.rb
+++ b/lib/hanzo.rb
@@ -8,9 +8,19 @@ require 'hanzo/heroku'
 require 'hanzo/version'
 
 module Hanzo
-  def self.run(command)
+  def self.run(command, fetch_output = false)
     print(command, :green)
-    ::Bundler.with_clean_env { system(command) }
+    output = true
+
+    ::Bundler.with_clean_env do
+      if fetch_output
+        output = `#{command}`
+      else
+        system(command)
+      end
+    end
+
+    output
   end
 
   def self.print(text = '', *colors)

--- a/lib/hanzo/modules/config.rb
+++ b/lib/hanzo/modules/config.rb
@@ -34,7 +34,7 @@ module Hanzo
     def fetch_variables
       @variables = Hanzo::Installers::Remotes.environments.keys.inject({}) do |memo, env|
         # Fetch the variables over at Heroku
-        config = Hanzo.run("heroku config -r #{env}").split("\n")
+        config = Hanzo.run("heroku config -r #{env}", true).split("\n")
 
         # Reject the first line (Heroku header)
         config = config.reject { |line| line =~ /^=/ }

--- a/spec/cli/config_spec.rb
+++ b/spec/cli/config_spec.rb
@@ -34,8 +34,8 @@ RUBY
         Hanzo.should_receive(:title).with(fetch_environment_title)
         Hanzo.should_receive(:title).with(compare_environment_title)
 
-        Hanzo.should_receive(:run).with("#{config_cmd} -r #{environment_one_name}").and_return(environment_one)
-        Hanzo.should_receive(:run).with("#{config_cmd} -r #{environment_two_name}").and_return(environment_two)
+        Hanzo.should_receive(:run).with("#{config_cmd} -r #{environment_one_name}", true).and_return(environment_one)
+        Hanzo.should_receive(:run).with("#{config_cmd} -r #{environment_two_name}", true).and_return(environment_two)
 
         Hanzo.should_receive(:print).with("Missing variables in #{environment_one_name}", :yellow)
         Hanzo.should_receive(:print).with(['- SMTP_USERNAME'])


### PR DESCRIPTION
`Hanzo.run` was recently modified to ditch its return value — but we need it in the `config compare` command.

This pull request adds a `fetch_output` argument that makes the method use the _`_ method instead of `Kernel#system` (because we must keep using `Kernel#system` to stream the command output).

We might want to refactor `Hanzo.run` later to use `IO.popen`.
