### PR TITLE
Do not depend on Bundler to run stuff

### DIFF
--- a/lib/hanzo.rb
+++ b/lib/hanzo.rb
@@ -12,7 +12,7 @@ module Hanzo
     print(command, :green)
     output = true
 
-    ::Bundler.with_clean_env do
+    _run do
       if fetch_output
         output = `#{command}`
       else
@@ -21,6 +21,14 @@ module Hanzo
     end
 
     output
+  end
+
+  def self._run(&blk)
+    if defined?(Bundle)
+      ::Bundle.with_clean_env(&blk)
+    else
+      blk.call
+    end
   end
 
   def self.print(text = '', *colors)


### PR DESCRIPTION
If `hanzo` is not called with `bundle exec hanzo`, that doesn’t mean we can’t still try to run stuff.
