### PR TITLE
Update rspec 'should' syntax to remove deprecation warnings

### DIFF
--- a/hanzo.gemspec
+++ b/hanzo.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'phare', '~> 0.6'
   spec.add_development_dependency 'rubocop', '~> 0.24'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec', '~> 3.1'
 
   spec.add_dependency 'highline', '>= 1.6.19'
 end

--- a/spec/cli/config_spec.rb
+++ b/spec/cli/config_spec.rb
@@ -5,7 +5,7 @@ describe Hanzo::CLI do
     let(:config!) { Hanzo::CLI.new(['config', action]) }
     let(:heroku_remotes) { { 'production' => 'heroku-app-production', 'qa' => 'heroku-app-qa' } }
 
-    before { Hanzo::Installers::Remotes.stub(:environments).and_return(heroku_remotes) }
+    before { expect(Hanzo::Installers::Remotes).to receive(:environments).and_return(heroku_remotes) }
 
     describe :compare do
       let(:action) { 'compare' }
@@ -31,16 +31,16 @@ describe Hanzo::CLI do
       end
 
       before do
-        Hanzo.should_receive(:title).with(fetch_environment_title)
-        Hanzo.should_receive(:title).with(compare_environment_title)
+        expect(Hanzo).to receive(:title).with(fetch_environment_title)
+        expect(Hanzo).to receive(:title).with(compare_environment_title)
 
-        Hanzo.should_receive(:run).with("#{config_cmd} -r #{environment_one_name}", true).and_return(environment_one)
-        Hanzo.should_receive(:run).with("#{config_cmd} -r #{environment_two_name}", true).and_return(environment_two)
+        expect(Hanzo).to receive(:run).with("#{config_cmd} -r #{environment_one_name}", true).and_return(environment_one)
+        expect(Hanzo).to receive(:run).with("#{config_cmd} -r #{environment_two_name}", true).and_return(environment_two)
 
-        Hanzo.should_receive(:print).with("Missing variables in #{environment_one_name}", :yellow)
-        Hanzo.should_receive(:print).with(['- SMTP_USERNAME'])
-        Hanzo.should_receive(:print).with("Missing variables in #{environment_two_name}", :yellow)
-        Hanzo.should_receive(:print).with(['- SMTP_PASSWORD', '- SMTP_HOST'])
+        expect(Hanzo).to receive(:print).with("Missing variables in #{environment_one_name}", :yellow)
+        expect(Hanzo).to receive(:print).with(['- SMTP_USERNAME'])
+        expect(Hanzo).to receive(:print).with("Missing variables in #{environment_two_name}", :yellow)
+        expect(Hanzo).to receive(:print).with(['- SMTP_PASSWORD', '- SMTP_HOST'])
       end
 
       it 'should install specified labs for each environment' do

--- a/spec/cli/deploy_spec.rb
+++ b/spec/cli/deploy_spec.rb
@@ -17,10 +17,9 @@ describe Hanzo::CLI do
     let(:deploy_cmd) { "git push -f #{env} #{branch}:master" }
 
     before do
-      Dir.should_receive(:exist?).with(migration_dir).and_return(migrations_exist)
-      Hanzo::Installers::Remotes.stub(:environments).and_return(heroku_remotes)
-      Hanzo.should_receive(:ask).with(deploy_question).and_return(branch)
-      Hanzo.should_receive(:run).with(deploy_cmd).once
+      expect(Dir).to receive(:exist?).with(migration_dir).and_return(migrations_exist)
+      expect(Hanzo).to receive(:ask).with(deploy_question).and_return(branch)
+      expect(Hanzo).to receive(:run).with(deploy_cmd).once
     end
 
     context 'without migration' do
@@ -34,9 +33,9 @@ describe Hanzo::CLI do
 
       context 'that should be ran' do
         before do
-          Hanzo.should_receive(:agree).with(migration_question).and_return(true)
-          Hanzo.should_receive(:run).with(migration_cmd)
-          Hanzo.should_receive(:run).with(restart_cmd)
+          expect(Hanzo).to receive(:agree).with(migration_question).and_return(true)
+          expect(Hanzo).to receive(:run).with(migration_cmd)
+          expect(Hanzo).to receive(:run).with(restart_cmd)
         end
 
         it 'should run migrations' do
@@ -46,9 +45,9 @@ describe Hanzo::CLI do
 
       context 'that should not be ran' do
         before do
-          Hanzo.should_receive(:agree).with(migration_question).and_return(false)
-          Hanzo.should_not_receive(:run).with(migration_cmd)
-          Hanzo.should_not_receive(:run).with(restart_cmd)
+          expect(Hanzo).to receive(:agree).with(migration_question).and_return(false)
+          expect(Hanzo).not_to receive(:run).with(migration_cmd)
+          expect(Hanzo).not_to receive(:run).with(restart_cmd)
         end
 
         it 'should not run migrations' do

--- a/spec/cli/install_spec.rb
+++ b/spec/cli/install_spec.rb
@@ -14,16 +14,16 @@ describe Hanzo::CLI do
       let(:enable_labs_info) { '- Enabled for' }
 
       before do
-        Hanzo::Installers::Remotes.stub(:environments).and_return(heroku_remotes)
-        Hanzo::Heroku.stub(:available_labs).and_return(available_labs)
-        Hanzo.should_receive(:title).with(labs_title)
+        expect(Hanzo::Installers::Remotes).to receive(:environments).and_return(heroku_remotes)
+        expect(Hanzo::Heroku).to receive(:available_labs).and_return(available_labs)
+        expect(Hanzo).to receive(:title).with(labs_title)
 
         available_labs.each do |name, _|
-          Hanzo.should_receive(:agree).with("Add #{name}?").and_return(true)
+          expect(Hanzo).to receive(:agree).with("Add #{name}?").and_return(true)
 
           heroku_remotes.each do |env, _|
-            Hanzo.should_receive(:run).with("#{enable_labs_cmd} #{name} --remote #{env}")
-            Hanzo.should_receive(:print).with("#{enable_labs_info} #{env}")
+            expect(Hanzo).to receive(:run).with("#{enable_labs_cmd} #{name} --remote #{env}")
+            expect(Hanzo).to receive(:print).with("#{enable_labs_info} #{env}")
           end
         end
       end
@@ -37,15 +37,16 @@ describe Hanzo::CLI do
       let(:type) { 'remotes' }
       let(:create_remotes_title) { 'Creating git remotes' }
 
-      before { Hanzo.should_receive(:title).with(create_remotes_title) }
+      before { expect(Hanzo).to receive(:title).with(create_remotes_title) }
 
       context '.heroku-remotes exists' do
         before do
-          Hanzo::Installers::Remotes.stub(:environments).and_return(heroku_remotes)
+          expect(Hanzo::Installers::Remotes).to receive(:environments).and_return(heroku_remotes)
+
           heroku_remotes.each do |env, app|
-            Hanzo.should_receive(:print).with("Adding #{env}")
-            Hanzo.should_receive(:run).with("git remote rm #{env} 2>&1 > /dev/null")
-            Hanzo.should_receive(:run).with("git remote add #{env} git@heroku.com:#{app}.git")
+            expect(Hanzo).to receive(:print).with("Adding #{env}")
+            expect(Hanzo).to receive(:run).with("git remote rm #{env} 2>&1 > /dev/null")
+            expect(Hanzo).to receive(:run).with("git remote add #{env} git@heroku.com:#{app}.git")
           end
         end
 
@@ -55,10 +56,10 @@ describe Hanzo::CLI do
       end
 
       context '.heroku-remotes file is missing' do
-        before { Hanzo.should_receive(:print).twice }
+        before { expect(Hanzo).to receive(:print).twice }
 
         it 'should display error message' do
-          lambda { install! }.should raise_error SystemExit
+          expect { install! }.to raise_error SystemExit
         end
       end
     end


### PR DESCRIPTION
Use the new `:expect` syntax for RSpec to remove the following deprecation warnings:

```
Deprecation Warnings:

Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new
 `:expect` syntax or explicitly enable `:should` instead. Called from /Volumes/Mirego/hanzo/spec/cli/install_spec.rb:40:in `blo
ck (4 levels) in <top (required)>'.

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new 
`:expect` syntax or explicitly enable `:should` instead. Called from /Volumes/Mirego/hanzo/spec/cli/install_spec.rb:61:in `bloc
k (5 levels) in <top (required)>'.
```
