### PR TITLE
Add error handling for deployment on uninstalled environments

### DIFF
--- a/lib/hanzo.rb
+++ b/lib/hanzo.rb
@@ -7,6 +7,8 @@ require 'hanzo/cli'
 require 'hanzo/heroku'
 require 'hanzo/version'
 
+require 'hanzo/fetchers/environment'
+
 module Hanzo
   def self.run(command, fetch_output = false)
     print(command, :green)
@@ -35,6 +37,11 @@ module Hanzo
     colors = colors.map { |c| HighLine.const_get(c.to_s.upcase) }
     text = text.join("\n       ") if text.is_a?(Array)
     HighLine.say HighLine.color("       #{text}", *colors)
+  end
+
+  def self.unindent_print(text = '', *colors)
+    colors = colors.map { |c| HighLine.const_get(c.to_s.upcase) }
+    HighLine.say HighLine.color(text, *colors)
   end
 
   def self.title(text)

--- a/lib/hanzo/fetchers/environment.rb
+++ b/lib/hanzo/fetchers/environment.rb
@@ -1,0 +1,27 @@
+module Hanzo
+  module Fetchers
+    class Environment
+      def initialize(env)
+        @env = env
+      end
+
+      def exist?
+        environments.include?(@env)
+      end
+
+      def installed?
+        installed_environments.include?(@env)
+      end
+
+    protected
+
+      def installed_environments
+        Hanzo::Installers::Remotes.installed_environments
+      end
+
+      def environments
+        Hanzo::Installers::Remotes.environments
+      end
+    end
+  end
+end

--- a/lib/hanzo/modules/deploy.rb
+++ b/lib/hanzo/modules/deploy.rb
@@ -1,5 +1,8 @@
 module Hanzo
   class Deploy < Base
+    UnknownEnvironment = Class.new(StandardError)
+    UninstalledEnvironment = Class.new(StandardError)
+
   protected
 
     def initialize_variables
@@ -12,6 +15,11 @@ module Hanzo
 
       deploy
       run_migrations
+    rescue UnknownEnvironment
+      Hanzo.unindent_print "Environment `#{@env}` doesn't exist. Add it to .heroku-remotes and run:\n  hanzo install remotes", :red
+      Hanzo.unindent_print "\nFor more information, read https://github.com/mirego/hanzo#install-remotes", :red
+    rescue UninstalledEnvironment
+      Hanzo.unindent_print "Environment `#{@env}` has been found in your .heroku-remotes file. Before using it, you must install it:\n  hanzo install remotes", :red
     end
 
     def initialize_help
@@ -27,6 +35,8 @@ module Hanzo
     end
 
     def deploy
+      validate_environment_existence!
+
       branch = Hanzo.ask("Branch to deploy in #{@env}:") { |q| q.default = 'HEAD' }
 
       Hanzo.run "git push -f #{@env} #{branch}:master"
@@ -38,6 +48,15 @@ module Hanzo
 
       Hanzo.run "heroku run rake db:migrate --remote #{@env}"
       Hanzo.run "heroku ps:restart --remote #{@env}"
+    end
+
+    def validate_environment_existence!
+      raise UnknownEnvironment unless fetcher.exist?
+      raise UninstalledEnvironment unless fetcher.installed?
+    end
+
+    def fetcher
+      @fetcher ||= Hanzo::Fetchers::Environment.new(@env)
     end
   end
 end

--- a/lib/hanzo/modules/installers/remotes.rb
+++ b/lib/hanzo/modules/installers/remotes.rb
@@ -22,6 +22,10 @@ module Hanzo
         Hanzo.print 'For more information, please read https://github.com/mirego/hanzo'
         exit
       end
+
+      def self.installed_environments
+        `git remote`.split("\n")
+      end
     end
   end
 end

--- a/spec/cli/deploy_spec.rb
+++ b/spec/cli/deploy_spec.rb
@@ -17,6 +17,9 @@ describe Hanzo::CLI do
     let(:deploy_cmd) { "git push -f #{env} #{branch}:master" }
 
     before do
+      expect(Hanzo::Installers::Remotes).to receive(:environments).and_return(['production'])
+      expect(Hanzo::Installers::Remotes).to receive(:installed_environments).and_return(['production'])
+
       expect(Dir).to receive(:exist?).with(migration_dir).and_return(migrations_exist)
       expect(Hanzo).to receive(:ask).with(deploy_question).and_return(branch)
       expect(Hanzo).to receive(:run).with(deploy_cmd).once
@@ -38,9 +41,7 @@ describe Hanzo::CLI do
           expect(Hanzo).to receive(:run).with(restart_cmd)
         end
 
-        it 'should run migrations' do
-          deploy!
-        end
+        specify { deploy! }
       end
 
       context 'that should not be ran' do
@@ -50,9 +51,7 @@ describe Hanzo::CLI do
           expect(Hanzo).not_to receive(:run).with(restart_cmd)
         end
 
-        it 'should not run migrations' do
-          deploy!
-        end
+        specify { deploy! }
       end
     end
   end

--- a/spec/fetchers/environment_spec.rb
+++ b/spec/fetchers/environment_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Hanzo::Fetchers::Environment do
+  let(:fetcher) { Hanzo::Fetchers::Environment.new(current_environment) }
+  let(:current_environment) { 'production' }
+
+  describe :exist? do
+    let(:environments) { ['production'] }
+
+    before { expect(fetcher).to receive(:environments).and_return(environments) }
+
+    context 'with an existing environment' do
+      it { expect(fetcher.exist?).to be_truthy }
+    end
+
+    context 'with an unexisting environment' do
+      let(:current_environment) { 'staging' }
+      it { expect(fetcher.exist?).to be_falsey }
+    end
+  end
+
+  describe :installed? do
+    let(:environments) { ['production'] }
+
+    before { expect(fetcher).to receive(:installed_environments).and_return(environments) }
+
+    context 'with an installed environment' do
+      it { expect(fetcher.installed?).to be_truthy }
+    end
+
+    context 'with an uninstalled environment' do
+      let(:current_environment) { 'staging' }
+      it { expect(fetcher.installed?).to be_falsey }
+    end
+  end
+
+  describe :installed_environments do
+    before { expect(Hanzo::Installers::Remotes).to receive(:installed_environments) }
+
+    specify { fetcher.send(:installed_environments) }
+  end
+
+  describe :environments do
+    before { expect(Hanzo::Installers::Remotes).to receive(:environments) }
+
+    specify { fetcher.send(:environments) }
+  end
+end


### PR DESCRIPTION
Instead of having a Git error, we are now handling some cases. Before, the error wasn't so helpful for someone who is not used to Hanzo.
```
-----> Branch to deploy in boom: |HEAD| 
       git push -f boom HEAD:master
fatal: 'boom' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
       Run migrations? 
```
In case the environment can be found un `.heroku-remotes` but wasn't installed:
```
> be hanzo deploy production
Environment `production` has been found in your .heroku-remotes file. Before using it, you must install it:
  hanzo install remotes
```

In case the environment can't be found anywhere:
```
> be hanzo deploy boom
Environment `boom` doesn't exist. Add it to .heroku-remotes and run:
  hanzo install remotes

For more information, read https://github.com/mirego/hanzo#install-remotes
```