### PR TITLE
Only ask to run migrations on successful deploy

### DIFF
--- a/lib/hanzo.rb
+++ b/lib/hanzo.rb
@@ -18,7 +18,7 @@ module Hanzo
       if fetch_output
         output = `#{command}`
       else
-        system(command)
+        output = system(command)
       end
     end
 

--- a/lib/hanzo/modules/deploy.rb
+++ b/lib/hanzo/modules/deploy.rb
@@ -13,8 +13,7 @@ module Hanzo
     def initialize_cli
       initialize_help && return if @env.nil?
 
-      deploy
-      run_migrations
+      deploy && run_migrations
     rescue UnknownEnvironment
       Hanzo.unindent_print "Environment `#{@env}` doesn't exist. Add it to .heroku-remotes and run:\n  hanzo install remotes", :red
       Hanzo.unindent_print "\nFor more information, read https://github.com/mirego/hanzo#install-remotes", :red

--- a/spec/cli/deploy_spec.rb
+++ b/spec/cli/deploy_spec.rb
@@ -5,7 +5,6 @@ describe Hanzo::CLI do
     let(:env) { 'production' }
     let(:branch) { '1.0.0' }
     let(:deploy!) { Hanzo::CLI.new(['deploy', env]) }
-    let(:migrations_exist) { false }
     let(:heroku_remotes) { { 'production' => 'heroku-app-production' } }
     let(:migration_dir) { 'db/migrate' }
 
@@ -19,34 +18,64 @@ describe Hanzo::CLI do
     before do
       expect(Hanzo::Installers::Remotes).to receive(:environments).and_return(['production'])
       expect(Hanzo::Installers::Remotes).to receive(:installed_environments).and_return(['production'])
-
-      expect(Dir).to receive(:exist?).with(migration_dir).and_return(migrations_exist)
-      expect(Hanzo).to receive(:ask).with(deploy_question).and_return(branch)
-      expect(Hanzo).to receive(:run).with(deploy_cmd).once
     end
 
-    context 'without migration' do
+    context 'successful deploy and without migrations' do
+      let(:migrations_exist) { false }
+      let(:deploy_result) { true }
+
+      before do
+        expect(Dir).to receive(:exist?).with(migration_dir).and_return(migrations_exist)
+        expect(Hanzo).to receive(:ask).with(deploy_question).and_return(branch)
+        expect(Hanzo).to receive(:run).with(deploy_cmd).once.and_return(deploy_result)
+      end
+
       it 'should git push to heroku upstream' do
         deploy!
       end
     end
 
-    context 'with migrations' do
+    context 'with existing migrations' do
       let(:migrations_exist) { true }
 
-      context 'that should be ran' do
-        before do
-          expect(Hanzo).to receive(:agree).with(migration_question).and_return(true)
-          expect(Hanzo).to receive(:run).with(migration_cmd)
-          expect(Hanzo).to receive(:run).with(restart_cmd)
-        end
-
-        specify { deploy! }
+      before do
+        expect(Hanzo).to receive(:ask).with(deploy_question).and_return(branch)
+        expect(Hanzo).to receive(:run).with(deploy_cmd).once.and_return(deploy_result)
       end
 
-      context 'that should not be ran' do
+      context 'with successful deploy' do
+        let(:deploy_result) { true }
+
         before do
-          expect(Hanzo).to receive(:agree).with(migration_question).and_return(false)
+          expect(Dir).to receive(:exist?).with(migration_dir).and_return(migrations_exist)
+        end
+
+        context 'and migrations that should be ran' do
+          before do
+            expect(Hanzo).to receive(:agree).with(migration_question).and_return(true)
+            expect(Hanzo).to receive(:run).with(migration_cmd)
+            expect(Hanzo).to receive(:run).with(restart_cmd)
+          end
+
+          specify { deploy! }
+        end
+
+        context 'and migrations that should not be ran' do
+          before do
+            expect(Hanzo).to receive(:agree).with(migration_question).and_return(false)
+            expect(Hanzo).not_to receive(:run).with(migration_cmd)
+            expect(Hanzo).not_to receive(:run).with(restart_cmd)
+          end
+
+          specify { deploy! }
+        end
+      end
+
+      context 'without successful deploy' do
+        let(:deploy_result) { false }
+
+        before do
+          expect(Hanzo).not_to receive(:agree).with(migration_question)
           expect(Hanzo).not_to receive(:run).with(migration_cmd)
           expect(Hanzo).not_to receive(:run).with(restart_cmd)
         end


### PR DESCRIPTION
When we deploy new code, let’s make sure the deploy went OK before we ask if we want to run the migrations.