### PR TITLE
Add “hanzo diff” command

### DIFF
--- a/lib/hanzo/cli.rb
+++ b/lib/hanzo/cli.rb
@@ -1,4 +1,5 @@
 require 'hanzo/modules/deploy'
+require 'hanzo/modules/diff'
 require 'hanzo/modules/install'
 require 'hanzo/modules/config'
 
@@ -31,6 +32,7 @@ module Hanzo
 
         Available actions:
            deploy - Deploy a branch or a tag
+             diff - Show the diff between HEAD and the current release
           install - Install Hanzo configuration
            config - Manage Heroku configuration variables
 

--- a/lib/hanzo/modules/diff.rb
+++ b/lib/hanzo/modules/diff.rb
@@ -1,0 +1,51 @@
+module Hanzo
+  class Diff < Base
+    # Classes
+    UnknownEnvironment = Class.new(StandardError)
+    UninstalledEnvironment = Class.new(StandardError)
+
+  protected
+
+    def initialize_variables
+      @env = extract_argument(1)
+      @env ||= Hanzo::Installers::Remotes.environments.keys.first
+    end
+
+    def initialize_cli
+      initialize_help && return if @env.nil?
+
+      diff
+    rescue UnknownEnvironment
+      Hanzo.unindent_print "Environment `#{@env}` doesn't exist. Add it to .heroku-remotes and run:\n  hanzo install remotes", :red
+      Hanzo.unindent_print "\nFor more information, read https://github.com/mirego/hanzo#install-remotes", :red
+    rescue UninstalledEnvironment
+      Hanzo.unindent_print "Environment `#{@env}` has been found in your .heroku-remotes file. Before using it, you must install it:\n  hanzo install remotes", :red
+    end
+
+    def initialize_help
+      @options.banner = <<-BANNER.unindent
+        Usage: hanzo diff ENVIRONMENT
+
+        Available environments
+      BANNER
+
+      Hanzo::Installers::Remotes.environments.each do |env|
+        @options.banner << "  - #{env.first}\n"
+      end
+    end
+
+    def diff
+      validate_environment_existence!
+      Hanzo.run "git remote update #{@env} && git diff #{@env}/master...HEAD"
+    end
+
+    def validate_environment_existence!
+      raise UnknownEnvironment unless fetcher.exist?
+      raise UninstalledEnvironment unless fetcher.installed?
+    end
+
+    def fetcher
+      @fetcher ||= Hanzo::Fetchers::Environment.new(@env)
+    end
+  end
+end

--- a/spec/cli/diff_spec.rb
+++ b/spec/cli/diff_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Hanzo::CLI do
+  describe :diff do
+    let(:env) { 'production' }
+    let(:diff!) { Hanzo::CLI.new(['diff', env]) }
+    let(:heroku_remotes) { { 'production' => 'heroku-app-production' } }
+
+    let(:diff_cmd) { "git remote update #{env} && git diff #{env}/master...HEAD" }
+
+    before do
+      expect(Hanzo::Installers::Remotes).to receive(:environments).and_return(['production'])
+      expect(Hanzo::Installers::Remotes).to receive(:installed_environments).and_return(['production'])
+    end
+
+    context 'successful diff' do
+      let(:diff_result) { true }
+
+      before do
+        expect(Hanzo).to receive(:run).with(diff_cmd).once.and_return(diff_result)
+      end
+
+      it 'should update the right remote and run a diff' do
+        diff!
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pretty simple. Running this command:

```bash
$ hanzo diff production
git remote update production && git diff production/master...HEAD
```

Outputs this result:

```diff
──────────────────────────────────────────────────────────────────────────────────
 -- a/app/assets/javascripts/foo.js
 ++ b/app/assets/javascripts/foo.js
──────────────────────────────────────────────────────────────────────────────────
@@ -11,6 +11,7 @@ import {FooType} from 'foo/types';
 const SETTINGS = {
   autoplay: 5000,
+  loop: true,
   fade: {
     crossFade: true
   },

──────────────────────────────────────────────────────────────────────────────────
 -- a/app/assets/stylesheets/foo.scss
 ++ b/app/assets/stylesheets/foo.scss
──────────────────────────────────────────────────────────────────────────────────
@@ -122,15 +122,6 @@
   font-size: 30px;
 }

 .foo__title {
-  font-size: 30px;
+  font-size: 40px;
}
```