### PR TITLE
Add support for “after deploy” commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,17 @@ gem 'hanzo'
 Create an `.hanzo.yml` file at the root of your app that will contain a map of
 remotes, with the remote as the key and the Heroku application name as the value.
 
+You can also specify commands that can be ran on the application after a
+successful deploy. Hanzo will prompt to run each of them, they each will be ran
+with `heroku run` and the application will be restarted at the end.
+
 ```yaml
 remotes:
   qa: heroku-app-name-qa
   staging: heroku-app-name-staging
   production: heroku-app-name-production
+after_deploy:
+  - rake db:migrate
 ```
 
 ### Install remotes

--- a/spec/cli/deploy_spec.rb
+++ b/spec/cli/deploy_spec.rb
@@ -2,32 +2,23 @@ require 'spec_helper'
 
 describe Hanzo::CLI do
   describe :deploy do
-    let(:env) { 'production' }
-    let(:branch) { '1.0.0' }
-    let(:deploy!) { Hanzo::CLI.new(['deploy', env]) }
-    let(:heroku_remotes) { { 'production' => 'heroku-app-production' } }
-    let(:migration_dir) { 'db/migrate' }
-
-    let(:migration_question) { 'Run database migrations?' }
-    let(:deploy_question) { "Branch to deploy in #{env}:" }
-
-    let(:migration_cmd) { "heroku run rake db:migrate --remote #{env}" }
-    let(:restart_cmd) { "heroku ps:restart --remote #{env}" }
-    let(:deploy_cmd) { "git push -f #{env} #{branch}:master" }
+    let(:deploy!) { Hanzo::CLI.new(['deploy', 'production']) }
+    let(:deploy_question) { 'Branch to deploy in production:' }
+    let(:deploy_command) { "git push -f production 1.0.0:master" }
 
     before do
       expect(Hanzo::Installers::Remotes).to receive(:environments).and_return(['production'])
       expect(Hanzo::Installers::Remotes).to receive(:installed_environments).and_return(['production'])
     end
 
-    context 'successful deploy and without migrations' do
-      let(:migrations_exist) { false }
+    context 'successful deploy and without after_deploy commands' do
       let(:deploy_result) { true }
+      let(:config) { {} }
 
       before do
-        expect(Dir).to receive(:exist?).with(instance_of(String)).at_least(:once).and_return(migrations_exist)
-        expect(Hanzo).to receive(:ask).with(deploy_question).and_return(branch)
-        expect(Hanzo).to receive(:run).with(deploy_cmd).once.and_return(deploy_result)
+        allow(Hanzo).to receive(:config).and_return(config)
+        expect(Hanzo).to receive(:ask).with(deploy_question).and_return('1.0.0')
+        expect(Hanzo).to receive(:run).with(deploy_command).once.and_return(deploy_result)
       end
 
       it 'should git push to heroku upstream' do
@@ -35,49 +26,37 @@ describe Hanzo::CLI do
       end
     end
 
-    context 'with existing migrations' do
-      let(:migrations_exist) { true }
+    context 'with existing after_deploy commands' do
+      let(:config) { { 'after_deploy' => %w(foo bar) } }
 
       before do
-        expect(Hanzo).to receive(:ask).with(deploy_question).and_return(branch)
-        expect(Hanzo).to receive(:run).with(deploy_cmd).once.and_return(deploy_result)
+        allow(Hanzo).to receive(:config).and_return(config)
+        expect(Hanzo).to receive(:ask).with(deploy_question).and_return('1.0.0')
+        expect(Hanzo).to receive(:run).with(deploy_command).once.and_return(deploy_result)
       end
 
       context 'with successful deploy' do
         let(:deploy_result) { true }
 
         before do
-          expect(Dir).to receive(:exist?).with(instance_of(String)).at_least(:once).and_return(migrations_exist)
+          expect(Hanzo).to receive(:agree).with('Run `foo` on production?').and_return(true)
+          expect(Hanzo).to receive(:run).with('heroku run foo --remote production')
+          expect(Hanzo).to receive(:agree).with('Run `bar` on production?').and_return(true)
+          expect(Hanzo).to receive(:run).with('heroku run bar --remote production')
+          expect(Hanzo).to receive(:run).with('heroku ps:restart --remote production')
         end
 
-        context 'and migrations that should be ran' do
-          before do
-            expect(Hanzo).to receive(:agree).with(migration_question).and_return(true)
-            expect(Hanzo).to receive(:run).with(migration_cmd)
-            expect(Hanzo).to receive(:run).with(restart_cmd)
-          end
-
-          specify { deploy! }
-        end
-
-        context 'and migrations that should not be ran' do
-          before do
-            expect(Hanzo).to receive(:agree).with(migration_question).and_return(false)
-            expect(Hanzo).not_to receive(:run).with(migration_cmd)
-            expect(Hanzo).not_to receive(:run).with(restart_cmd)
-          end
-
-          specify { deploy! }
-        end
+        specify { deploy! }
       end
 
       context 'without successful deploy' do
         let(:deploy_result) { false }
 
         before do
-          expect(Hanzo).not_to receive(:agree).with(migration_question)
-          expect(Hanzo).not_to receive(:run).with(migration_cmd)
-          expect(Hanzo).not_to receive(:run).with(restart_cmd)
+          expect(Hanzo).not_to receive(:agree)
+          expect(Hanzo).not_to receive(:run).with('heroku run foo --remote production')
+          expect(Hanzo).not_to receive(:run).with('heroku run bar --remote production')
+          expect(Hanzo).not_to receive(:run).with('heroku ps:restart --remote production')
         end
 
         specify { deploy! }


### PR DESCRIPTION
Instead of hard-coding Rails and Ecto (and any other framework/library we might end up supporting) migration directories and command in the gem, we’ll leave that up to the user.

### Rails migrations

```yaml
remotes:
   production: heroku-app-name-production
after_deploy:
  - rake db:migrate
```

### Ecto migrations

```yaml
remotes:
   production: heroku-app-name-production
after_deploy:
  - mix ecto.migrate
```

🔪 💥 