### PR TITLE
Modify deploy module to only restart if needed

### DIFF
--- a/lib/hanzo/modules/deploy.rb
+++ b/lib/hanzo/modules/deploy.rb
@@ -45,12 +45,15 @@ module Hanzo
     def run_after_deploy_commands
       return unless after_deploy_commands.any?
 
+      restart_needed = false
+
       after_deploy_commands.each do |command|
         next unless Hanzo.agree("Run `#{command}` on #{@env}?")
         Hanzo.run "heroku run #{command} --remote #{@env}"
+        restart_needed = true
       end
 
-      Hanzo.run "heroku ps:restart --remote #{@env}"
+      Hanzo.run "heroku ps:restart --remote #{@env}" if restart_needed
     end
 
     def after_deploy_commands

--- a/spec/cli/deploy_spec.rb
+++ b/spec/cli/deploy_spec.rb
@@ -39,14 +39,33 @@ describe Hanzo::CLI do
         let(:deploy_result) { true }
 
         before do
-          expect(Hanzo).to receive(:agree).with('Run `foo` on production?').and_return(true)
-          expect(Hanzo).to receive(:run).with('heroku run foo --remote production')
-          expect(Hanzo).to receive(:agree).with('Run `bar` on production?').and_return(true)
-          expect(Hanzo).to receive(:run).with('heroku run bar --remote production')
-          expect(Hanzo).to receive(:run).with('heroku ps:restart --remote production')
+          expect(Hanzo).to receive(:agree).with('Run `foo` on production?').and_return(agree_after_deploy_result)
+          expect(Hanzo).to receive(:agree).with('Run `bar` on production?').and_return(agree_after_deploy_result)
         end
 
-        specify { deploy! }
+        context 'with after_deploy commands skipped' do
+          let(:agree_after_deploy_result) { false }
+
+          before do
+            expect(Hanzo).not_to receive(:run).with('heroku run foo --remote production')
+            expect(Hanzo).not_to receive(:run).with('heroku run bar --remote production')
+            expect(Hanzo).not_to receive(:run).with('heroku ps:restart --remote production')
+          end
+
+          specify { deploy! }
+        end
+
+        context 'without after_deploy commands skipped' do
+          let(:agree_after_deploy_result) { true }
+
+          before do
+            expect(Hanzo).to receive(:run).with('heroku run foo --remote production')
+            expect(Hanzo).to receive(:run).with('heroku run bar --remote production')
+            expect(Hanzo).to receive(:run).with('heroku ps:restart --remote production')
+          end
+
+          specify { deploy! }
+        end
       end
 
       context 'without successful deploy' do


### PR DESCRIPTION
Currently for each `after deploy` commands, we have the option to run or not this command. If I choose not to run any `after deploy` commands, a restart is send for this application to Heroku which we result in one extra restart not needed.

With this PR, we now only send a restart command if one of the available `after deploy` commands is send to Heroku.