### PR TITLE
Add support for “hanzo deploy <environment> <reference>”

### DIFF
--- a/lib/hanzo/modules/deploy.rb
+++ b/lib/hanzo/modules/deploy.rb
@@ -9,6 +9,7 @@ module Hanzo
     def initialize_variables
       @env = extract_argument(1)
       @env ||= Hanzo::Installers::Remotes.environments.keys.first
+      @branch = extract_argument(2)
     end
 
     def initialize_cli
@@ -37,7 +38,7 @@ module Hanzo
     def deploy
       validate_environment_existence!
 
-      branch = Hanzo.ask("Branch to deploy in #{@env}:") { |q| q.default = 'HEAD' }
+      branch = @branch || Hanzo.ask("Branch to deploy in #{@env}:") { |q| q.default = 'HEAD' }
 
       Hanzo.run "git push -f #{@env} #{branch}:master"
     end

--- a/spec/cli/deploy_spec.rb
+++ b/spec/cli/deploy_spec.rb
@@ -11,6 +11,23 @@ describe Hanzo::CLI do
       expect(Hanzo::Installers::Remotes).to receive(:installed_environments).and_return(['production'])
     end
 
+    context 'deploy with specific branch' do
+      let(:deploy!) { Hanzo::CLI.new(['deploy', 'production', '2.0.0']) }
+      let(:deploy_command) { "git push -f production 2.0.0:master" }
+      let(:deploy_result) { true }
+      let(:config) { {} }
+
+      before do
+        allow(Hanzo).to receive(:config).and_return(config)
+        expect(Hanzo).not_to receive(:ask)
+        expect(Hanzo).to receive(:run).with(deploy_command).once.and_return(deploy_result)
+      end
+
+      it 'should git push to heroku upstream' do
+        deploy!
+      end
+    end
+
     context 'successful deploy and without after_deploy commands' do
       let(:deploy_result) { true }
       let(:config) { {} }


### PR DESCRIPTION
We’re now able to run : 

```bash
$ hanzo deploy qa v0.1.5
```

and skip the prompt altogether! 🚀 