### PR TITLE
Add “hanzo console” command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ remotes:
 
 after_deploy:
   - rake db:migrate
+
+console: rails console
 ```
 
 ### `hanzo install`
@@ -167,6 +169,20 @@ $ hanzo config compare
        - SMTP_PORT
        - SMTP_SERVER
        - SMTP_USER
+```
+
+### `hanzo console`
+
+You can define a `console` command in `.hanzo.yml` to quickly spawn a console
+process using `heroku run`.
+
+```bash
+$ hanzo console qa
+```
+
+```
+Running iex -S mix on heroku-app-name-qa... up
+> |
 ```
 
 ## License

--- a/lib/hanzo/cli.rb
+++ b/lib/hanzo/cli.rb
@@ -2,6 +2,7 @@ require 'hanzo/modules/deploy'
 require 'hanzo/modules/diff'
 require 'hanzo/modules/install'
 require 'hanzo/modules/config'
+require 'hanzo/modules/console'
 
 module Hanzo
   class CLI < Base
@@ -35,6 +36,7 @@ module Hanzo
              diff - Show the diff between HEAD and the current release
           install - Install Hanzo configuration
            config - Manage Heroku configuration variables
+          console - Run a console command
 
         Options:
       BANNER

--- a/lib/hanzo/modules/console.rb
+++ b/lib/hanzo/modules/console.rb
@@ -1,0 +1,57 @@
+module Hanzo
+  class Console < Base
+    # Classes
+    UnknownEnvironment = Class.new(StandardError)
+    UninstalledEnvironment = Class.new(StandardError)
+    UnknownCommand = Class.new(StandardError)
+
+    def initialize_variables
+      @env = extract_argument(1)
+    end
+
+    def initialize_cli
+      initialize_help && return if @env.nil?
+
+      validate_environment_existence!
+
+      console
+    rescue UnknownCommand
+      Hanzo.unindent_print 'A “console” command is needed in `.hanzo.yml`', :red
+    rescue UnknownEnvironment
+      Hanzo.unindent_print "Environment `#{@env}` doesn't exist. Add it to .hanzo.yml and run:\n  hanzo install remotes", :red
+      Hanzo.unindent_print "\nFor more information, read https://github.com/mirego/hanzo#remotes", :red
+    rescue UninstalledEnvironment
+      Hanzo.unindent_print "Environment `#{@env}` has been found in your .hanzo.yml file. Before using it, you must install it:\n  hanzo install remotes", :red
+    end
+
+    def console
+      command = Hanzo.config['console']
+      raise UnknownCommand unless command
+
+      Hanzo.run "heroku run --remote #{@env} #{command}"
+    end
+
+  protected
+
+    def initialize_help
+      @options.banner = <<-BANNER.unindent
+        Usage: hanzo console ENVIRONMENT
+
+        Available environments
+      BANNER
+
+      Hanzo::Installers::Remotes.environments.each do |env|
+        @options.banner << "  - #{env.first}\n"
+      end
+    end
+
+    def validate_environment_existence!
+      raise UnknownEnvironment unless fetcher.exist?
+      raise UninstalledEnvironment unless fetcher.installed?
+    end
+
+    def fetcher
+      @fetcher ||= Hanzo::Fetchers::Environment.new(@env)
+    end
+  end
+end


### PR DESCRIPTION
I find myself typing `heroku run -r qa iex -S mix` often and it seems to me that I should just be able to type `hanzo console qa` to achieve the same thing.

Now I can! 🎉 😄 