### PR TITLE
Use Heroku’s HTTPS transport for Git remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ $ hanzo install remotes
 -----> Creating git remotes
        Adding qa
         git remote rm qa 2>&1 > /dev/null
-        git remote add qa git@heroku.com:heroku-app-name-qa.git
+        git remote add qa https://git.heroku.com/heroku-app-name-qa.git
        Adding staging
         git remote rm staging 2>&1 > /dev/null
-        git remote add staging git@heroku.com:heroku-app-name-staging.git
+        git remote add staging https://git.heroku.com/heroku-app-name-staging.git
        Adding production
         git remote rm production 2>&1 > /dev/null
-        git remote add production git@heroku.com:heroku-app-name-production.git
+        git remote add production https://git.heroku.com/heroku-app-name-production.git
 ```
 
 #### Labs
@@ -188,7 +188,7 @@ Running iex -S mix on heroku-app-name-qa... up
 ## License
 
 `Hanzo` is © 2013-2018 [Mirego](http://www.mirego.com) and may be freely
-distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause).  See the
+distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the
 [`LICENSE.md`](https://github.com/mirego/hanzo/blob/master/LICENSE.md) file.
 
 ## About Mirego

--- a/lib/hanzo/modules/installers/remotes.rb
+++ b/lib/hanzo/modules/installers/remotes.rb
@@ -12,7 +12,7 @@ module Hanzo
       def self.add_remote(app, env)
         Hanzo.print "Adding #{env}"
         Hanzo.run "git remote rm #{env} 2>&1 > /dev/null"
-        Hanzo.run "git remote add #{env} git@heroku.com:#{app}.git"
+        Hanzo.run "git remote add #{env} https://git.heroku.com/#{app}.git"
       end
 
       def self.environments

--- a/spec/cli/install_spec.rb
+++ b/spec/cli/install_spec.rb
@@ -46,7 +46,7 @@ describe Hanzo::CLI do
           heroku_remotes.each do |env, app|
             expect(Hanzo).to receive(:print).with("Adding #{env}")
             expect(Hanzo).to receive(:run).with("git remote rm #{env} 2>&1 > /dev/null")
-            expect(Hanzo).to receive(:run).with("git remote add #{env} git@heroku.com:#{app}.git")
+            expect(Hanzo).to receive(:run).with("git remote add #{env} https://git.heroku.com/#{app}.git")
           end
         end
 


### PR DESCRIPTION
Heroku has [deprecated its SSH Git Transport](https://devcenter.heroku.com/articles/git#ssh-git-transport) in favor of HTTP(S) transport.